### PR TITLE
Add background replacement technique for COCO Instance Segmentation

### DIFF
--- a/clodsa/clodsa/augmentors/cocoSequentialInstanceSegmentationAugmentor.py
+++ b/clodsa/clodsa/augmentors/cocoSequentialInstanceSegmentationAugmentor.py
@@ -95,15 +95,10 @@ class COCOSequentialInstanceSegmentationAugmentor(IAugmentor):
     def applyAugmentation(self):
         self.readImagesAndAnnotations()
 
-        newannotations = Parallel(n_jobs=1)(delayed(readAndGenerateInstanceSegmentation)
+        newannotations = Parallel(n_jobs=-1)(delayed(readAndGenerateInstanceSegmentation)
                                              (self.outputPath, self.transformers, self.imagesPath, self.dictImages[x],
                                               self.dictAnnotations[x],self.ignoreClasses)
                                              for x in self.dictImages.keys())
-
-        #newannotations = []
-        #for x in self.dictImages.keys():
-        #    a = readAndGenerateInstanceSegmentation(self.outputPath, self.transformers, self.imagesPath, self.dictImages[x], self.dictAnnotations[x],self.ignoreClasses)
-        #    newannotations.append(a)
 
         data = {}
         data['info'] = self.info

--- a/clodsa/clodsa/augmentors/cocoSequentialInstanceSegmentationAugmentor.py
+++ b/clodsa/clodsa/augmentors/cocoSequentialInstanceSegmentationAugmentor.py
@@ -43,11 +43,10 @@ def readAndGenerateInstanceSegmentation(outputPath, transformers, inputPath, ima
             (newimage, newmasklabels) = transformer.transform(image, maskLabels)
             print("maskLabesl: ".format(maskLabels))
             print("newMaskLabels: ".format(newmasklabels))
+            image = newimage
+            maskLabels = newmasklabels
         except:
             print("Error in image: " + imagePath)
-
-        image = newimage
-        maskLabels = newmasklabels
 
     (hI,wI) =newimage.shape[:2]
     cv2.imwrite(outputPath + str(j) + "_" + name, newimage)
@@ -96,10 +95,15 @@ class COCOSequentialInstanceSegmentationAugmentor(IAugmentor):
     def applyAugmentation(self):
         self.readImagesAndAnnotations()
 
-        newannotations = Parallel(n_jobs=-1)(delayed(readAndGenerateInstanceSegmentation)
+        newannotations = Parallel(n_jobs=1)(delayed(readAndGenerateInstanceSegmentation)
                                              (self.outputPath, self.transformers, self.imagesPath, self.dictImages[x],
                                               self.dictAnnotations[x],self.ignoreClasses)
                                              for x in self.dictImages.keys())
+
+        #newannotations = []
+        #for x in self.dictImages.keys():
+        #    a = readAndGenerateInstanceSegmentation(self.outputPath, self.transformers, self.imagesPath, self.dictImages[x], self.dictAnnotations[x],self.ignoreClasses)
+        #    newannotations.append(a)
 
         data = {}
         data['info'] = self.info

--- a/clodsa/clodsa/techniques/backgroundReplacementAugmentationTechnique.py
+++ b/clodsa/clodsa/techniques/backgroundReplacementAugmentationTechnique.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import
+from .technique import BackgroundReplaceTechnique
+import cv2
+import numpy as np
+import os
+import random
+
+class backgroundReplacementAugmentationTechnique(BackgroundReplaceTechnique):
+
+    # Valid values for kernel are 3,5,7,9, and 11
+    def __init__(self,parameters):
+        BackgroundReplaceTechnique.__init__(self, parameters)
+        self.parameters = parameters
+
+    def apply(self, image):
+        #blurred = cv2.blur(image, (self.kernel, self.kernel))
+        return image
+
+    def apply2(self, image, maskLabels):
+        
+        # list all files and get only images
+        bkg_img_files = os.listdir(self.parameters["background_images_dir"])
+        bkg_img_files = [f for f in bkg_img_files if ((".jpg" in f) or (".png" in f))]
+        # load and resize one random background image
+        bkg_img = cv2.imread(os.path.join(self.parameters["background_images_dir"], random.sample(bkg_img_files,1)[0]))
+        bkg_img = cv2.resize(bkg_img, (image.shape[1],image.shape[0]), interpolation = cv2.INTER_AREA)
+
+        instance_mask = np.ones(maskLabels[0][0].shape)
+        instance_mask = (instance_mask == 0)
+        instance_mask = np.dstack((instance_mask,instance_mask,instance_mask))
+        #background = np.full(image.shape,np.array([0,255,0]))
+        for mask, label in maskLabels:
+            bool_mask = mask > 0
+            bool_mask = np.dstack((bool_mask,bool_mask,bool_mask))
+            np.logical_or(instance_mask, bool_mask, instance_mask)
+        image = np.where(instance_mask, image, bkg_img)
+        return image

--- a/clodsa/clodsa/techniques/technique.py
+++ b/clodsa/clodsa/techniques/technique.py
@@ -10,9 +10,6 @@ class Technique(with_metaclass(ABCMeta, object)):
     def apply(self, image):
         raise NotImplementedError
 
-
-
-
 class PositionVariantTechnique(with_metaclass(ABCMeta, Technique)):
     def __init__(self, parameters=None):
         Technique.__init__(self, parameters)
@@ -29,3 +26,14 @@ class PositionInvariantTechnique(with_metaclass(ABCMeta, Technique)):
     def apply(self, image):
         raise NotImplementedError
 
+class BackgroundReplaceTechnique(with_metaclass(ABCMeta, Technique)):
+    def __init__(self, parameters=None):
+        Technique.__init__(self, parameters)
+
+    @abstractmethod
+    def apply(self, image):
+        raise NotImplementedError
+
+    @abstractmethod
+    def apply2(self, image, maskLabels):
+        raise NotImplementedError

--- a/clodsa/clodsa/techniques/techniqueList.py
+++ b/clodsa/clodsa/techniques/techniqueList.py
@@ -29,6 +29,7 @@ from .changeToHSVAugmentationTechnique import changeToHSVAugmentationTechnique
 from .changeToLABAugmentationTechnique import changeToLABAugmentationTechnique
 from .invertAugmentationTechnique import invertAugmentationTechnique
 from .cropSizeAugmentationTechnique import cropSizeAugmentationTechnique
+from .backgroundReplacementAugmentationTechnique import backgroundReplacementAugmentationTechnique
 
 Techniques = {
     "average_blurring" : averageBlurringAugmentationTechnique,
@@ -60,5 +61,6 @@ Techniques = {
     "sharpen":sharpenAugmentationTechnique,
     "shift_channel":shiftChannelAugmentationTechnique,
     "shearing": shearingAugmentationTechnique,
-    "translation": translationAugmentationTechnique
+    "translation": translationAugmentationTechnique,
+    "background_replacement": backgroundReplacementAugmentationTechnique
 }

--- a/clodsa/clodsa/transformers/transformerForImageInstanceSegmentation.py
+++ b/clodsa/clodsa/transformers/transformerForImageInstanceSegmentation.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from .transformer import Transformer
-from ..techniques.technique import PositionVariantTechnique
+from ..techniques.technique import PositionVariantTechnique, BackgroundReplaceTechnique
+
 
 
 
@@ -10,10 +11,16 @@ class TransformerForImageInstanceSegmentation(Transformer):
         Transformer.__init__(self,technique,dictLabels)
 
     def transform(self, image,maskLabels):
-        if (isinstance(self.technique, PositionVariantTechnique)):
+        if (isinstance(self.technique, BackgroundReplaceTechnique)):
+            return [self.technique.apply2(image, maskLabels),
+                    [(mask, self.transformLabel(label))
+                     for mask, label in maskLabels]]
+
+        elif (isinstance(self.technique, PositionVariantTechnique)):
             return [self.technique.apply(image),
                     [(self.technique.apply(mask), self.transformLabel(label))
                      for mask,label in maskLabels ]]
+
         else:
             return [self.technique.apply(image),
                     [(mask, self.transformLabel(label))


### PR DESCRIPTION
Implementation of the background replacement technique for the COCO Instance Segmentation problem. This works by giving an input directory where background images are stored, creating a ***background_replacement*** technique and passing the input directory in the parameters dictionary. The technique will:

- Load and resize a random background image to fit the image to augment
- Create a mask of all objects instances
- Replace all pixels that do not correspond to instances with the corresponding pixel (same position) from the background image.
- The labels and masks remain unchanged.
